### PR TITLE
Deletions only, notification and permission removed, ARRL kept.

### DIFF
--- a/text/part_80.md
+++ b/text/part_80.md
@@ -4282,7 +4282,9 @@ The Group A and B frequency pairs listed in the table in paragraph (a)(2) of thi
 
 TABLE at [80.385(3)](https://www.law.cornell.edu/cfr/text/47/80.385#3)
 <a name="80.385a4"></a>
-  - (4) Channels in the 219-220 MHz band are also used on a secondary, non-interference basis by amateur stations participating in digital message forwarding systems. Amateur stations may not cause harmful interference to AMTS operations and must accept any harmful interference from AMTS operation. Amateur stations within 80 km (50 miles) of an AMTS coast station must obtain written approval from the AMTS licensee prior to operating in the 219-220 MHz band. Amateur stations within 640 km (398 miles) of an AMTS coast station must notify the AMTS licensee in writing at least 30 days prior to initiation of operations in the 219-220 MHz band. All amateur stations must notify the American Radio Relay League in writing at least 30 days prior to initiation of operations in the 219-220 MHz band (ARRL, 225 Main St., Newington, CT 06111-1494).
+  - (4) Channels in the 219-220 MHz band are also used on a secondary, non-interference basis by amateur stations. 
+  Amateur stations may not cause harmful interference to AMTS operations and must accept any harmful interference from AMTS operation. 
+  All amateur stations must notify the American Radio Relay League in writing at least 30 days prior to initiation of operations in the 219-220 MHz band (ARRL, 225 Main St., Newington, CT 06111-1494).
 <a name="80.385b"></a>
 - (b) Subject to the requirements of § 1.924 of this chapter, §§ [80.215(h)](#80.215h), and [80.475(a)](#80.475a), each AMTS geographic area licensee may place stations anywhere within its region without obtaining prior Commission approval provided:
 <a name="80.385b1"></a>

--- a/text/part_97.md
+++ b/text/part_97.md
@@ -1158,7 +1158,7 @@ TABLE at [97.303(h)](https://www.law.cornell.edu/cfr/text/47/97.303#h)
 - (l)
 In the 219-220 MHz segment:
 <a name="97.303l1"></a>
-  - (1) Use is restricted to amateur stations participating as forwarding stations in fixed point-to-point digital message forwarding systems, including intercity packet backbone networks. It is not available for other purposes.
+  - (1) (deleted)
 <a name="97.303l2"></a>
   - (2) Amateur stations must not cause harmful interference to, and must accept interference from, stations authorized by:
 <a name="97.303l2i"></a>

--- a/text/part_97.md
+++ b/text/part_97.md
@@ -1168,9 +1168,9 @@ In the 219-220 MHz segment:
 <a name="97.303l3"></a>
   - (3) No amateur station may transmit unless the licensee has given written notification of the station's specific geographic location for such transmissions in order to be incorporated into a database that has been made available to the public. The notification must be given at least 30 days prior to making such transmissions. The notification must be given to: The American Radio Relay League, Inc., 225 Main Street, Newington, CT 06111-1494.
 <a name="97.303l4"></a>
-  - (4) No amateur station may transmit from a location that is within 640 km of an AMTS coast station that operates in the 217-218 MHz and 219-220 MHz bands unless the amateur station licensee has given written notification of the station's specific geographic location for such transmissions to the AMTS licensee. The notification must be given at least 30 days prior to making such transmissions. The location of AMTS coast stations using the 217-218/219-220 MHz channels may be obtained as noted in paragraph (l)(3) of this section.
+  - (4) (deleted)
 <a name="97.303l5"></a>
-  - (5) No amateur station may transmit from a location that is within 80 km of an AMTS coast station that uses frequencies in the 217-218 MHz and 219-220 MHz bands unless that amateur station licensee holds written approval from that AMTS licensee. The location of AMTS coast stations using the 217-218/219-220 MHz channels may be obtained as noted in paragraph (l)(3) of this section.
+  - (5) (deleted)
 <a name="97.303m"></a>
 - (m)
 In the 70 cm band:


### PR DESCRIPTION
Keeps the notification to ARRL, removes the permission/notification to AMTS licensees.
Keeps hams as a secondary user.